### PR TITLE
Add a deterministic IV generator for AES-GCM

### DIFF
--- a/crypto/cipher_extra/aead_test.cc
+++ b/crypto/cipher_extra/aead_test.cc
@@ -1217,3 +1217,23 @@ TEST(AEADTest, WycheproofXChaCha20Poly1305) {
 TEST(AEADTest, FreeNull) {
   EVP_AEAD_CTX_free(nullptr);
 }
+
+// Deterministic IV generation for AES-GCM 256.
+TEST(AEADTest, AEADAES256GCMDetIVGen) {
+  EXPECT_FALSE(EVP_AEAD_aes_256_gcm_det_iv_gen(0, 0, nullptr, 0));
+
+  uint8_t out[EVP_AEAD_AES_256_GCM_DET_IV_LEN] = {0};
+  EXPECT_FALSE(EVP_AEAD_aes_256_gcm_det_iv_gen(0, 0, out, 0));
+
+  uint32_t ip_address = UINT32_C(0xcdfbf267);  // amazon.com when I checked.
+  uint64_t fake_time = UINT64_C(0x1122334455667788);
+  uint8_t expected[EVP_AEAD_AES_256_GCM_DET_IV_LEN] = {
+    // TODO: This is the little-endian representation of those values; do we
+    // support any big-endian platforms?
+    0x67, 0xf2, 0xfb, 0xcd, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11
+  };
+
+  EXPECT_TRUE(EVP_AEAD_aes_256_gcm_det_iv_gen(ip_address, fake_time,
+      out, sizeof(out)));
+  EXPECT_EQ(Bytes(out, sizeof(out)), Bytes(expected, sizeof(expected)));
+}

--- a/crypto/fipsmodule/cipher/aead.c
+++ b/crypto/fipsmodule/cipher/aead.c
@@ -285,3 +285,21 @@ int EVP_AEAD_CTX_tag_len(const EVP_AEAD_CTX *ctx, size_t *out_tag_len,
   *out_tag_len = extra_in_len + ctx->tag_len;
   return 1;
 }
+
+// EVP_aead_aes_256_gcm_det_iv_gen computes a deterministic IV compliant with
+// NIST SP 800-38D, built from an IPv4 address and the number of nanoseconds
+// since boot, writing it to |out_iv|. It returns one on success or zero for
+// error. |out_iv_len| must be exactly 12 bytes (96 bits).
+int EVP_AEAD_aes_256_gcm_det_iv_gen(const uint32_t ip_address,
+    const uint64_t time_since_boot, uint8_t *out_iv,
+    const size_t out_iv_len) {
+  if (out_iv == NULL || out_iv_len != EVP_AEAD_AES_256_GCM_DET_IV_LEN) {
+    return 0;
+  }
+
+  OPENSSL_memcpy(out_iv, &ip_address, sizeof(ip_address));
+  OPENSSL_memcpy(out_iv + sizeof(ip_address), &time_since_boot,
+                 sizeof(time_since_boot));
+
+  return 1;
+}

--- a/include/openssl/aead.h
+++ b/include/openssl/aead.h
@@ -244,6 +244,10 @@ struct evp_aead_ctx_st {
 // be used.
 #define EVP_AEAD_DEFAULT_TAG_LENGTH 0
 
+// EVP_AEAD_AES_256_GCM_DET_IV_LEN is the number of bytes required for 96 bits
+// of deterministically-generated IV to be used in AES-GCM.
+#define EVP_AEAD_AES_256_GCM_DET_IV_LEN 12
+
 // EVP_AEAD_CTX_zero sets an uninitialized |ctx| to the zero state. It must be
 // initialized with |EVP_AEAD_CTX_init| before use. It is safe, but not
 // necessary, to call |EVP_AEAD_CTX_cleanup| in this state. This may be used for
@@ -463,6 +467,12 @@ OPENSSL_EXPORT int EVP_AEAD_CTX_tag_len(const EVP_AEAD_CTX *ctx,
                                         const size_t in_len,
                                         const size_t extra_in_len);
 
+// EVP_aead_aes_256_gcm_det_iv_gen computes a deterministic IV compliant with
+// NIST SP 800-38D, built from an IPv4 address and the number of nanoseconds
+// since boot, writing it to |out_iv|. It returns one on success or zero for
+// error. |out_iv_len| must be exactly 12 bytes (96 bits).
+OPENSSL_EXPORT int EVP_AEAD_aes_256_gcm_det_iv_gen(const uint32_t ip_address,
+    const uint64_t time_since_boot, uint8_t *out_iv, const size_t out_iv_len);
 
 #if defined(__cplusplus)
 }  // extern C


### PR DESCRIPTION
### Issues:
Resolves CryptoAlg-1205

### Description of changes: 
Adds a simple deterministic IV generator for AES-GCM, turning an IP address and passed-in nonseconds value into an IV.

### Call-outs:
The test for this has a little-endian expected result, and I sort of hate that. But I don't know if we support any big-endian platforms.

### Testing:
Unit tests for failure cases, and for success/expected output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
